### PR TITLE
Added hashed card id endpoint that responds with member details

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,30 @@ module.exports = {
             }
         });
         
+        app.get('/member', function(req, res){
+            if (req.query.card_id_hash) {
+                res.locals.User.findOne({where: {card_id_hashed: req.query.card_id_hash}}, function (err, member) {
+                    if (member) {
+                        res.status(200).send({
+                            name: member.name,
+                            email: member.email,
+                            active: member.is_active(),
+                            permission: member.permission
+                        });
+                    }
+                    else {
+                        res.status(404).send({
+                            success: false,
+                            message: "Hashed Card ID not found"
+                        });
+                    }
+                });
+            }
+            else {
+                res.status(400).send("No identity specified.");
+            }
+        });
+        
         return app;
     }
 }


### PR DESCRIPTION
Given a correct hashed card ID it will respond with `HTTP 200` and JSON along the lines of:

    {
        name: "Members Sign Up Name",
        email: "Members@E-mail.com",
        active: true,
        permission: 100
    }

Note: Active is simply the same result as the /identify endpoint but with JSON boolean.

I also added in the users email and I figured that might be useful in some cases.

Or in a failing state it will respond with success: false and a message as well as being some kind of not `HTTP 200`, for example a hash that doesn't exist:

    {
        success: false,
        message: "Hashed Card ID not found"
    }